### PR TITLE
Add chat UI and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ OpenEdge-LLM bundles everything you need to build a modern, multimodal assistant
 - **Edge-to-Cloud** deployment from GPUs to sub‑1W microcontrollers
 - **Multimodal** ingestion of text, images and sensor data
 - **One-Click Demo** to show off your smart home or factory assistant
+- **Built-in Chat** interface with simple conversation history
 
 ## Project Layers and Technologies
 
@@ -177,14 +178,14 @@ docker-compose -f devops/docker-compose.yml up --build
   ```
 
 ### 10. Frontend & APIs
-- Start FastAPI backend (health, file/image upload, RAG API):
+- Start FastAPI backend (health, file/image upload, RAG API, chat endpoint):
   ```sh
   uvicorn frontend/backend/main:app --reload
   uvicorn frontend/backend/file_api:app --reload
   uvicorn frontend/backend/image_api:app --reload
   uvicorn frontend/backend/rag_api:app --reload
   ```
-- Visit [http://localhost:3000](http://localhost:3000) for the Next.js UI.
+- Visit [http://localhost:3000](http://localhost:3000) for the Next.js UI and try chatting.
 
 ### 11. DevOps, CI/CD & Monitoring
 - GitHub Actions: Automated tests and builds on push to main.

--- a/frontend/backend/main.py
+++ b/frontend/backend/main.py
@@ -1,8 +1,45 @@
-# Minimal FastAPI app for backend
+# FastAPI backend with simple chat endpoint
+import os
+import sys
+from typing import List, Dict
+
 from fastapi import FastAPI
+from pydantic import BaseModel
+
+# allow importing modules from repository root
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
+from intent_rag_backend.intent_router import IntentRouter
+from intent_rag_backend.rag_qa import answer_question
+from intent_rag_backend.summarizer import summarize
 
 app = FastAPI()
+router = IntentRouter()
+conversation_history: List[Dict[str, str]] = []
+
+class ChatRequest(BaseModel):
+    message: str
 
 @app.get("/health")
 def health():
     return {"status": "ok"}
+
+@app.get("/history")
+def history():
+    return conversation_history[-10:]
+
+@app.post("/chat")
+def chat(req: ChatRequest):
+    """Route user text to the proper handler and return a fun reply."""
+    intent = router.route(req.message)
+    if intent["action"] == "turn_on_lights":
+        reply = "Lights turned on."
+    elif intent["action"] == "turn_off_lights":
+        reply = "Lights turned off."
+    elif intent["action"] == "weather_query":
+        reply = "It's always sunny in the demo!"
+    else:
+        rag_result = answer_question(req.message, "The stove was last turned off at 8pm.")
+        reply = rag_result.get("answer", "I am not sure.")
+    summary = summarize(reply)
+    conversation_history.append({"user": req.message, "bot": summary})
+    return {"answer": summary, "action": intent["action"]}

--- a/frontend/web/pages/api/chat.js
+++ b/frontend/web/pages/api/chat.js
@@ -1,0 +1,17 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+  try {
+    const resp = await fetch('http://localhost:8000/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req.body)
+    });
+    const data = await resp.json();
+    res.status(200).json(data);
+  } catch (err) {
+    res.status(500).json({ error: 'Backend error' });
+  }
+}

--- a/frontend/web/pages/api/health.js
+++ b/frontend/web/pages/api/health.js
@@ -1,0 +1,5 @@
+export default async function handler(req, res) {
+  const resp = await fetch('http://localhost:8000/health');
+  const data = await resp.json();
+  res.status(200).json(data);
+}

--- a/frontend/web/pages/index.js
+++ b/frontend/web/pages/index.js
@@ -2,8 +2,45 @@ import { useEffect, useState } from 'react';
 
 export default function Home() {
   const [status, setStatus] = useState('');
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+
   useEffect(() => {
-    fetch('/api/health').then(res => res.json()).then(data => setStatus(data.status));
+    fetch('/api/health')
+      .then(res => res.json())
+      .then(data => setStatus(data.status));
   }, []);
-  return <div>Backend status: {status}</div>;
+
+  const send = async () => {
+    if (!input.trim()) return;
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: input })
+    });
+    const data = await res.json();
+    setMessages([...messages, { user: input, bot: data.answer }]);
+    setInput('');
+  };
+
+  return (
+    <div>
+      <h1>OpenEdge Chat</h1>
+      <p>Backend status: {status}</p>
+      <div>
+        {messages.map((m, idx) => (
+          <div key={idx} style={{ marginBottom: '1em' }}>
+            <strong>You:</strong> {m.user}<br />
+            <strong>Bot:</strong> {m.bot}
+          </div>
+        ))}
+      </div>
+      <input
+        value={input}
+        onChange={e => setInput(e.target.value)}
+        placeholder="Say something..."
+      />
+      <button onClick={send}>Send</button>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add a simple chat endpoint with history to the FastAPI backend
- expose backend via Next.js API routes
- build a basic chat UI on the front-end
- document the new chat feature

## Testing
- `python -m py_compile $(git ls-files '*.py')`