### PR TITLE
Add environment setup script and fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ git clone https://github.com/your-org/open-edge-llm.git
 cd open-edge-llm
 ```
 
-### 2. Configure Environment
-Copy the provided `.env.example` to `.env` and fill in your secrets as needed:
+### 2. Install Dependencies
+Run the helper script to install Python and Node requirements:
 ```sh
-cp devops/.env.example devops/.env
+bash devops/setup_env.sh
 ```
 
 ### 3. Launch Core Services (Dev)
@@ -185,7 +185,21 @@ docker-compose -f devops/docker-compose.yml up --build
   uvicorn frontend/backend/image_api:app --reload
   uvicorn frontend/backend/rag_api:app --reload
   ```
-- Visit [http://localhost:3000](http://localhost:3000) for the Next.js UI and try chatting.
+  - Visit [http://localhost:3000](http://localhost:3000) for the Next.js UI and try chatting.
+
+### Deploying the Next.js Frontend to Vercel
+Use the provided configuration in `frontend/web` to host the chat UI on Vercel.
+
+1. Install the Vercel CLI:
+   ```sh
+   npm install -g vercel
+   ```
+2. Deploy from within `frontend/web`:
+   ```sh
+   cd frontend/web
+   vercel --prod
+   ```
+   The command will output a URL for your deployed application. This environment cannot access Vercel to provide a live link.
 
 ### 11. DevOps, CI/CD & Monitoring
 - GitHub Actions: Automated tests and builds on push to main.

--- a/devops/setup_env.sh
+++ b/devops/setup_env.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+# Install Python dependencies
+pip install fastapi uvicorn requests apache-beam dask torch
+
+# Install Node.js dependencies for the Next.js frontend
+cd "$(dirname "$0")/../frontend/web"
+npm install
+
+cd - >/dev/null
+
+echo "Environment setup complete."
+

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,3 +1,28 @@
 # Front-end & APIs
 
-FastAPI backend and Next.js frontend. Example: Ask “Did I leave the stove on?” → assistant fuses last camera frame + sensor logs.
+FastAPI backend and a minimal Next.js frontend. Example: ask “Did I leave the stove on?” and the assistant fuses the last camera frame and sensor logs.
+
+## Local development
+
+1. Install dependencies inside `frontend/web` (or run `../../devops/setup_env.sh` from repo root):
+   ```sh
+   npm install
+   ```
+2. Run the Next.js dev server:
+   ```sh
+   npm run dev
+   ```
+3. Visit [http://localhost:3000](http://localhost:3000) to chat with the backend.
+
+## Deploying to Vercel
+
+1. Install the Vercel CLI if you haven't already:
+   ```sh
+   npm install -g vercel
+   ```
+2. Deploy from the `frontend/web` directory:
+   ```sh
+   cd frontend/web
+   vercel --prod
+   ```
+   The CLI will output the deployment URL. Because this development environment has no network access, a live link cannot be provided here.

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "openedge-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "12.3.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/frontend/web/vercel.json
+++ b/frontend/web/vercel.json
@@ -1,0 +1,3 @@
+{
+  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+}


### PR DESCRIPTION
## Summary
- document running `devops/setup_env.sh` instead of copying a missing .env
- mention the setup script in frontend README
- add `devops/setup_env.sh` to install Python and Node.js requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
